### PR TITLE
Force TLS 1.2, and pass a user agent to API calls

### DIFF
--- a/bin/fastly-tools.js
+++ b/bin/fastly-tools.js
@@ -16,6 +16,7 @@ program
 	.option('-V --verbose', 'Verbose log output')
 	.option('-a --autoactivate', 'Automatically activate valid versions without prompting')
 	.option('-b --backends <backends>', 'Upload the backend options specified in <backends> via the api')
+	.option('-u --useragent <user agent>', 'a user agent string to identify the tool in API logs')
 	.option('-k --api-keys <keys>', 'list of alternate api keys to try should the key stored in process.env.FASTLY_API_KEY hit its rate limit', list)
 	.option('--skip-conditions <conditions>', 'list of conditions to skip deleting', list)
 	.option('--skip-responses <responses>', 'list of responses to skip deleting', list)

--- a/lib/fastly/lib/index.js
+++ b/lib/fastly/lib/index.js
@@ -23,6 +23,7 @@ function Fastly (apikeys, service, options) {
 
 	this.service = service || '';
 	this.verbose = (opts.verbose) ? true : false;
+	this.useragent = (opts.useragent) ? opts.useragent : 'fastly-tools';
 
 	var self = this;
 
@@ -80,21 +81,37 @@ Fastly.prototype.request = function (method, url, params) {
 		debug('Request: ' + method + ', ' + url);
 
 		// Construct headers
-		var headers = { 'fastly-key': this.apikey };
+		var headers = {
+			'fastly-key': this.apikey,
+			'User-Agent': this.useragent
+		};
+
+		// Force TLS 1.2 in request
+		// https://www.npmjs.com/package/request
+		// https://nodejs.org/api/tls.html#tls_tls_connect_options_callback
+		// https://www.openssl.org/docs/man1.0.2/ssl/ssl.html#DEALING-WITH-PROTOCOL-METHODS
+		var agentOptions = {
+			secureProtocol: 'TLSv1_2_method'
+		};
 
 		// HTTP request
-		request({
+		const options = {
+			headers: headers,
+			agentOptions: agentOptions,
 			method: method,
 			url: 'https://api.fastly.com' + url,
-			headers: headers,
 			form: params
-		}, (err, response, body) => {
+		};
+
+		request(options, (err, response, body) => {
+
+			if (err || ! response) {
+				return reject(body);
+			}
 
 			if (this.verbose) {
 				debug('Response: ' + response.statusCode + ' ' + body);
 			}
-
-			if (err) return reject(body);
 
 			if (response.statusCode >= 400) return reject(body);
 			if (response.statusCode > 302) return resolve(body);
@@ -108,21 +125,22 @@ Fastly.prototype.request = function (method, url, params) {
 			console.log(method.toUpperCase() + ' to  ' + url + ' succeeded');
 			resolve(body);
 		});
-
 	})
-		.catch(err => {
-			if (err.msg && /You have exceeded your hourly rate limit/.test(err.msg) && this.apikeys.length) {
-				console.log(method.toUpperCase() + ' to  ' + url + ' hit rate limit');
-				this.apikey = this.apikeys.shift();
-				if (!this.apikey) {
-					console.log('no backup api keys available');
-					throw err;
-				}
-				return this.request(method, url, params)
+	.catch(err => {
+		if (err.msg && /You have exceeded your hourly rate limit/.test(err.msg) && this.apikeys.length) {
+			console.log(method.toUpperCase() + ' to  ' + url + ' hit rate limit');
+			this.apikey = this.apikeys.shift();
+			if (!this.apikey) {
+				console.log('no backup api keys available');
+				throw err;
 			}
-			console.log(method.toUpperCase() + ' to  ' + url + ' failed');
-			throw err;
-		});
+			return this.request(method, url, params)
+		} else {
+			console.log('Unknown error:' + err);
+		}
+		console.log(method.toUpperCase() + ' to  ' + url + ' failed');
+		throw err;
+	});
 
 };
 

--- a/tasks/deploy.js
+++ b/tasks/deploy.js
@@ -14,6 +14,7 @@ function task (folders, opts) {
 		service: null,
 		vars: [],
 		verbose: false,
+		useragent: 'fastly-tools',
 		autoactivate: false,
 		disableLogs: false,
 		backends: null,


### PR DESCRIPTION
 - Pass a user agent with all calls.  Allow options override for user agent to personalize calls if needed.
 - Force TLS 1.2 in advance of Fastly disabling lower TLS methods